### PR TITLE
Do not copy data to sublist

### DIFF
--- a/lib/changes/increaseItemDepth.js
+++ b/lib/changes/increaseItemDepth.js
@@ -59,7 +59,7 @@ function moveAsSubItem(
     const newSublist = Block.create({
         object: 'block',
         type: currentList.type,
-        data: currentList.data
+        data: {}
     });
 
     return editor.withoutNormalizing(() => {

--- a/tests/increase-item-depth-basic-with-data/expected.js
+++ b/tests/increase-item-depth-basic-with-data/expected.js
@@ -7,7 +7,7 @@ export default (
             <ul_list style={{ listStyleType: 'disc' }}>
                 <list_item>
                     <paragraph>First item</paragraph>
-                    <ul_list style={{ listStyleType: 'disc' }}>
+                    <ul_list>
                         <list_item>
                             <paragraph>Second item</paragraph>
                         </list_item>


### PR DESCRIPTION
Endrer slik at sublister ikkje arver data fra parent. Dette for å unngå problemer med at start-parameter fra liste tas med til underlista som sett her: https://github.com/NDLANO/editorial-frontend/pull/889#issuecomment-773181842