### PR TITLE
Unwrap all elements when unwrapping list

### DIFF
--- a/lib/changes/unwrapList.js
+++ b/lib/changes/unwrapList.js
@@ -26,13 +26,22 @@ function unwrapList(opts: Options, editor: Editor): editor {
         // Unwrap the items' children
         items.forEach(item =>
             item.nodes.forEach(node => {
-                if (node.get('type') === 'list-text') {
-                    // we wrap the text in paragraph instead of list-text, before moving it out if the list
-                    const textNode = node.nodes.first();
-                    editor.wrapBlockByKey(textNode.key, 'paragraph');
+                if (node.get('type') === opts.typeDefault) {
+                    // we wrap the first element in paragraph
+                    const firstNode = node.nodes.first();
+                    editor.wrapBlockByKey(firstNode.key, 'paragraph');
                     const paragraphNode = editor.value.document.getParent(
-                        textNode.key
+                        firstNode.key
                     );
+                    // Add the rest of the elements to the paragraph, before moving the paragraph
+                    // out of the list
+                    node.nodes.slice(1).forEach(innerNode => {
+                        editor.moveNodeByKey(
+                            innerNode.key,
+                            paragraphNode.key,
+                            index
+                        );
+                    });
                     editor.moveNodeByKey(paragraphNode.key, parent.key, index);
                     index += 1;
                 } else {

--- a/lib/changes/unwrapList.js
+++ b/lib/changes/unwrapList.js
@@ -35,11 +35,11 @@ function unwrapList(opts: Options, editor: Editor): editor {
                     );
                     // Add the rest of the elements to the paragraph, before moving the paragraph
                     // out of the list
-                    node.nodes.slice(1).forEach(innerNode => {
+                    node.nodes.slice(1).forEach((innerNode, nodeIndex) => {
                         editor.moveNodeByKey(
                             innerNode.key,
                             paragraphNode.key,
-                            index
+                            nodeIndex + 1
                         );
                     });
                     editor.moveNodeByKey(paragraphNode.key, parent.key, index);


### PR DESCRIPTION
Relatert til NDLANO/Issues#2502

Det kan oppstå tilfeller der en punktliste har `<li>`-element som inneholder mer enn én node. Slik ndla-slate-edit-list fungerer nå vil kun den første noden bli værende ved unwrapping. De andre nodene forsvinner.

Jeg forsøkte å finne en metode for å flytte alle nodene på en gang med slatejs, men den beste løsningen jeg har funnet inntil videre er å wrappe det første elementet i en paragraf og deretter flytte de resterende elementene inn etterpå.

Hvordan teste:
1. slate-edit-list: `yarn link`
2. ed: `yarn link "ndla-slate-edit-list"`
3. slate-edit-list: `yarn`
4. ed: `yarn start`
5. Åpne artikkel (feks 59229)
6. Marker bendik og trykk punktliste. Punktet skal forsvinne, men teksten skal forbli lik.